### PR TITLE
add hspec-discover to cabal file

### DIFF
--- a/hw-kafka-conduit.cabal
+++ b/hw-kafka-conduit.cabal
@@ -79,3 +79,4 @@ test-suite kafka-client-conduit-test
                       , resourcet
                       , transformers
                       , QuickCheck
+  build-tool-depends:   hspec-discover:hspec-discover


### PR DESCRIPTION
Very minor, just needed if you don't have hspec-discover globally installed