### PR TITLE
Compatability with latest hw-kafka-client version

### DIFF
--- a/hw-kafka-conduit.cabal
+++ b/hw-kafka-conduit.cabal
@@ -53,7 +53,6 @@ library
                       , bytestring
                       , containers
                       , conduit
-                      , conduit-extra
                       , exceptions
                       , hw-kafka-client >= 2.5
                       , mtl
@@ -73,7 +72,6 @@ test-suite kafka-client-conduit-test
                       , bytestring
                       , containers
                       , conduit
-                      , conduit-extra
                       , extra
                       , hspec
                       , hw-kafka-client >= 2.5

--- a/hw-kafka-conduit.cabal
+++ b/hw-kafka-conduit.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:                   hw-kafka-conduit
-version:                2.7.0
+version:                3.0.0
 synopsis:               Conduit bindings for hw-kafka-client
 homepage:               https://github.com/haskell-works/hw-kafka-conduit
 bug-reports:            https://github.com/haskell-works/hw-kafka-conduit/issues
@@ -52,9 +52,9 @@ library
                       , bifunctors
                       , bytestring
                       , containers
-                      , conduit
+                      , conduit >= 1.3.4 && < 1.4
                       , exceptions
-                      , hw-kafka-client >= 2.5
+                      , hw-kafka-client >= 2.5 && < 5.1
                       , mtl
                       , resourcet
                       , transformers

--- a/src/Kafka/Conduit/Sink.hs
+++ b/src/Kafka/Conduit/Sink.hs
@@ -1,6 +1,6 @@
 module Kafka.Conduit.Sink
 ( module X
-, kafkaSink, kafkaSinkAutoClose, kafkaSinkNoClose, kafkaBatchSinkNoClose
+, kafkaSink, kafkaSinkAutoClose, kafkaSinkNoClose
 , commitOffsetsSink, flushThenCommitSink
 ) where
 
@@ -50,23 +50,6 @@ kafkaSinkNoClose prod = go
           case res of
             Nothing  -> go
             Just err -> return (Just err)
-
--- | Creates a batching Sink for a given `KafkaProducer`.
--- The producer will NOT be closed automatically.
-kafkaBatchSinkNoClose :: MonadIO m
-                 => KafkaProducer
-                 -> ConduitT [ProducerRecord] Void m [(ProducerRecord, KafkaError)]
-kafkaBatchSinkNoClose prod = go
-  where
-    go = do
-      mbMsg <- await
-      case mbMsg of
-        Nothing -> return []
-        Just msgs -> do
-          res <- produceMessageBatch prod msgs
-          case res of
-            [] -> go
-            xs -> return xs
 
 -- | Creates a kafka producer for given properties and returns a Sink.
 --


### PR DESCRIPTION
The latest version of `hw-kafka-conduit` fails to build with the latest `hw-kafka-client` version (5.0.0), where `Kafka.Producer.produceMessageBatch` has been removed.
Also, the `conduit-extra` dependency seems redundant (at least with the latest `conduit` version, so I removed it.

Since this is a breaking change (removal of `kafkaBatchSinkNoClose`), this PR bumps the major version to `3.0.0`.